### PR TITLE
`maxBins` -> `maxBin`

### DIFF
--- a/sparkxgb/tests/classifier_test.py
+++ b/sparkxgb/tests/classifier_test.py
@@ -53,6 +53,7 @@ class XGBClassifierTests(unittest.TestCase):
         xgb_params = dict(
             eta=0.1,
             maxDepth=2,
+            maxBin=128,
             missing=0.0,
             objective="binary:logistic",
             numRound=5,

--- a/sparkxgb/xgboost.py
+++ b/sparkxgb/xgboost.py
@@ -47,7 +47,7 @@ class XGBoostClassifier(XGboostEstimator):
                  lambda_=1.0,  # Rename of 'lambda' param, as this is a reserved keyword in python.
                  lambdaBias=0.0,
                  leafPredictionCol=None,
-                 maxBins=16,
+                 maxBin=16,
                  maxDeltaStep=0.0,
                  maxDepth=6,
                  maxLeaves=None,
@@ -113,7 +113,7 @@ class XGBoostClassifier(XGboostEstimator):
                   lambda_=1.0,  # Rename of 'lambda' param, as this is a reserved keyword in python.
                   lambdaBias=0.0,
                   leafPredictionCol=None,
-                  maxBins=16,
+                  maxBin=16,
                   maxDeltaStep=0.0,
                   maxDepth=6,
                   maxLeaves=None,
@@ -203,7 +203,7 @@ class XGBoostRegressor(XGboostEstimator):
                  lambda_=1.0,  # Rename of 'lambda' param, as this is a reserved keyword in python.
                  lambdaBias=0.0,
                  leafPredictionCol=None,
-                 maxBins=16,
+                 maxBin=16,
                  maxDeltaStep=0.0,
                  maxDepth=6,
                  maxLeaves=None,
@@ -270,7 +270,7 @@ class XGBoostRegressor(XGboostEstimator):
                   lambda_=1.0,  # Rename of 'lambda' param, as this is a reserved keyword in python.
                   lambdaBias=0.0,
                   leafPredictionCol=None,
-                  maxBins=16,
+                  maxBin=16,
                   maxDeltaStep=0.0,
                   maxDepth=6,
                   maxLeaves=None,

--- a/sparkxgb/xgboost.py
+++ b/sparkxgb/xgboost.py
@@ -47,7 +47,7 @@ class XGBoostClassifier(XGboostEstimator):
                  lambda_=1.0,  # Rename of 'lambda' param, as this is a reserved keyword in python.
                  lambdaBias=0.0,
                  leafPredictionCol=None,
-                 maxBin=16,
+                 maxBin=128,
                  maxDeltaStep=0.0,
                  maxDepth=6,
                  maxLeaves=None,
@@ -113,7 +113,7 @@ class XGBoostClassifier(XGboostEstimator):
                   lambda_=1.0,  # Rename of 'lambda' param, as this is a reserved keyword in python.
                   lambdaBias=0.0,
                   leafPredictionCol=None,
-                  maxBin=16,
+                  maxBin=128,
                   maxDeltaStep=0.0,
                   maxDepth=6,
                   maxLeaves=None,
@@ -203,7 +203,7 @@ class XGBoostRegressor(XGboostEstimator):
                  lambda_=1.0,  # Rename of 'lambda' param, as this is a reserved keyword in python.
                  lambdaBias=0.0,
                  leafPredictionCol=None,
-                 maxBin=16,
+                 maxBin=128,
                  maxDeltaStep=0.0,
                  maxDepth=6,
                  maxLeaves=None,
@@ -270,7 +270,7 @@ class XGBoostRegressor(XGboostEstimator):
                   lambda_=1.0,  # Rename of 'lambda' param, as this is a reserved keyword in python.
                   lambdaBias=0.0,
                   leafPredictionCol=None,
-                  maxBin=16,
+                  maxBin=128,
                   maxDeltaStep=0.0,
                   maxDepth=6,
                   maxLeaves=None,

--- a/sparkxgb/xgboost.py
+++ b/sparkxgb/xgboost.py
@@ -47,7 +47,7 @@ class XGBoostClassifier(XGboostEstimator):
                  lambda_=1.0,  # Rename of 'lambda' param, as this is a reserved keyword in python.
                  lambdaBias=0.0,
                  leafPredictionCol=None,
-                 maxBin=128,
+                 maxBin=256,
                  maxDeltaStep=0.0,
                  maxDepth=6,
                  maxLeaves=None,
@@ -113,7 +113,7 @@ class XGBoostClassifier(XGboostEstimator):
                   lambda_=1.0,  # Rename of 'lambda' param, as this is a reserved keyword in python.
                   lambdaBias=0.0,
                   leafPredictionCol=None,
-                  maxBin=128,
+                  maxBin=256,
                   maxDeltaStep=0.0,
                   maxDepth=6,
                   maxLeaves=None,
@@ -203,7 +203,7 @@ class XGBoostRegressor(XGboostEstimator):
                  lambda_=1.0,  # Rename of 'lambda' param, as this is a reserved keyword in python.
                  lambdaBias=0.0,
                  leafPredictionCol=None,
-                 maxBin=128,
+                 maxBin=256,
                  maxDeltaStep=0.0,
                  maxDepth=6,
                  maxLeaves=None,
@@ -270,7 +270,7 @@ class XGBoostRegressor(XGboostEstimator):
                   lambda_=1.0,  # Rename of 'lambda' param, as this is a reserved keyword in python.
                   lambdaBias=0.0,
                   leafPredictionCol=None,
-                  maxBin=128,
+                  maxBin=256,
                   maxDeltaStep=0.0,
                   maxDepth=6,
                   maxLeaves=None,


### PR DESCRIPTION
## Background:
* The wrapper parameter for the base xgboost `max_bin` parameter was incorrectly pluralized as `maxBins`. This caused: `AttributeError: 'XGBoostClassifier' object has no attribute 'maxBins'` when trying to change the default value.

## Description of change
* Changed the parameter name to `maxBin` in definitions of `XGBoostClassifer` and `XGBoostRegressor` as well as set the new default value to `256` to mirror the default in base xgboost. (see https://xgboost.readthedocs.io/en/stable/parameter.html)
    * Added the `maxBin` parameter to `classifier_test.py` unit test.

## Testing Done
* Unit tests passed.